### PR TITLE
Fix issue with Range slider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ function App() {
 
   const [currentQR, setCurrentQR] = useState({
     mode: "preview",
-    data: "1",
+    data: 1,
   });
 
   const baseUrlValue =

--- a/src/components/Range.jsx
+++ b/src/components/Range.jsx
@@ -10,7 +10,7 @@ export default function Range({ value, label, onChange, min = 1, max = 100 }) {
           type="number"
           value={value}
           onChange={(e) => {
-            onChange(e.target.value);
+            onChange(parseInt(e.target.value));
           }}
           className="w-20 text-center border-0 h-6"
         />
@@ -20,7 +20,7 @@ export default function Range({ value, label, onChange, min = 1, max = 100 }) {
         type="range"
         value={value}
         onChange={(e) => {
-          onChange(e.target.value);
+          onChange(parseInt(e.target.value));
         }}
         min={min}
         max={max}


### PR DESCRIPTION
Fixes #2 

The range sliders currently set values as strings instead of numbers, this causes issues while generation. This PR adds a type conversion to Integer, so that range sliders function as intended.